### PR TITLE
Add Close() method to logger

### DIFF
--- a/internal/pkg/logger/file.go
+++ b/internal/pkg/logger/file.go
@@ -93,6 +93,11 @@ func (l *FileTransactionLogger) ReadEvents() (<-chan Event, <-chan error) {
 	return outEvent, outErr
 }
 
+func (l *FileTransactionLogger) Close() error {
+	close(l.events)
+	return l.file.Close()
+}
+
 type Event struct {
 	Sequence uint64
 	Kind     EventKind

--- a/internal/pkg/logger/postgres.go
+++ b/internal/pkg/logger/postgres.go
@@ -164,3 +164,8 @@ func (p *PostgresTransactionLogger) createTable() error {
 
 	return nil
 }
+
+func (p *PostgresTransactionLogger) Close() error {
+	close(p.events)
+	return nil
+}

--- a/internal/pkg/logger/transaction.go
+++ b/internal/pkg/logger/transaction.go
@@ -7,4 +7,5 @@ type TransactionLog interface {
 
 	Run()
 	ReadEvents() (<-chan Event, <-chan error)
+	Close() error
 }


### PR DESCRIPTION
- Add a `Close()` method to the `Logger` interface
- Basic implementation for both `File` and `Postgres` loggers
- Added synctest for `File` logger to ensure we don't leak any goroutines.