### PR TITLE
Add Postgress Logger tests

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -84,6 +84,7 @@ func main() {
 	svc := api.NewService(cache, log)
 	r := mux.NewRouter()
 
+	// TODO - the svc must have a way to close that lets it drain its requests then close the logger
 	r.HandleFunc("/v1/{key}", svc.PutForKey).Methods(http.MethodPut)
 	r.HandleFunc("/v1/{key}", svc.GetByKey).Methods(http.MethodGet)
 	r.HandleFunc("/v1/{key}", svc.DeleteKey).Methods(http.MethodDelete)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/treyburn/lockbox
 go 1.25.1
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/gorilla/mux v1.8.1
 	github.com/lib/pq v1.10.9
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/pkg/logger/postgres.go
+++ b/internal/pkg/logger/postgres.go
@@ -11,6 +11,7 @@ import (
 type PostgresTransactionLogger struct {
 	events chan<- Event
 	errors <-chan error
+	done   chan struct{}
 	db     *sql.DB
 }
 
@@ -67,17 +68,24 @@ func (p *PostgresTransactionLogger) Run() {
 	p.events = events
 	errs := make(chan error, 1)
 	p.errors = errs
+	done := make(chan struct{})
+	p.done = done
 
 	const insertQuery = `INSERT INTO transactions
 					(event_type, key, value)
 					VALUES ($1, $2, $3)`
 
 	go func() {
-		for e := range events {
-
-			_, err := p.db.Exec(insertQuery, e.Kind, e.Key, e.Value)
-			if err != nil {
-				errs <- fmt.Errorf("failed to write transaction: %w", err)
+		for {
+			select {
+			case <-p.done:
+				close(errs)
+				return
+			case e := <-events:
+				_, err := p.db.Exec(insertQuery, e.Kind, e.Key, e.Value)
+				if err != nil {
+					errs <- fmt.Errorf("failed to write transaction: %w", err)
+				}
 			}
 		}
 	}()
@@ -167,6 +175,7 @@ func (p *PostgresTransactionLogger) createTable() error {
 }
 
 func (p *PostgresTransactionLogger) Close() error {
-	close(p.events)
+	p.done <- struct{}{}
+	//close(p.events) TODO - figure out where to safely close this
 	return p.db.Close()
 }

--- a/internal/pkg/logger/postgres.go
+++ b/internal/pkg/logger/postgres.go
@@ -176,6 +176,6 @@ func (p *PostgresTransactionLogger) createTable() error {
 
 func (p *PostgresTransactionLogger) Close() error {
 	p.done <- struct{}{}
-	//close(p.events) TODO - figure out where to safely close this
+	// close(p.events) TODO - figure out where to safely close this
 	return p.db.Close()
 }

--- a/internal/pkg/logger/postgres.go
+++ b/internal/pkg/logger/postgres.go
@@ -126,27 +126,28 @@ func (p *PostgresTransactionLogger) ReadEvents() (<-chan Event, <-chan error) {
 func (p *PostgresTransactionLogger) verifyTableExists() (bool, error) {
 	const table = "transactions"
 
-	var result string
+	var result sql.NullString
 
 	rows, err := p.db.Query(fmt.Sprintf("SELECT to_regclass('public.%s');", table))
 	defer func() {
-		closeErr := rows.Close()
-		if closeErr != nil {
-			slog.Warn("failed to close db row", slog.String("error", closeErr.Error()))
+		if rows != nil {
+			if closeErr := rows.Close(); closeErr != nil {
+				slog.Warn("failed to close db row", slog.String("error", closeErr.Error()))
+			}
 		}
 	}()
 	if err != nil {
 		return false, err
 	}
 
-	for rows.Next() && result != table {
+	for rows.Next() && result.String != table {
 		err = rows.Scan(&result)
 		if err != nil {
 			return false, err
 		}
 	}
 
-	return result == table, rows.Err()
+	return result.String == table, rows.Err()
 }
 
 func (p *PostgresTransactionLogger) createTable() error {
@@ -167,5 +168,5 @@ func (p *PostgresTransactionLogger) createTable() error {
 
 func (p *PostgresTransactionLogger) Close() error {
 	close(p.events)
-	return nil
+	return p.db.Close()
 }

--- a/internal/pkg/logger/postgres_test.go
+++ b/internal/pkg/logger/postgres_test.go
@@ -1,0 +1,682 @@
+package logger
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewPostgresTransactionLogger tests the constructor
+func TestNewPostgresTransactionLogger(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Expect ping
+	mock.ExpectPing()
+
+	// Expect table existence check - table exists
+	rows := sqlmock.NewRows([]string{"to_regclass"}).AddRow("transactions")
+	mock.ExpectQuery(`SELECT to_regclass`).WillReturnRows(rows)
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	// Verify table exists returns true
+	exists, err := logger.verifyTableExists()
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestNewPostgresTransactionLogger_TableNotExists tests constructor when table doesn't exist
+func TestNewPostgresTransactionLogger_TableNotExists(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Expect table existence check - return NULL (table doesn't exist)
+	rows := sqlmock.NewRows([]string{"to_regclass"}).AddRow(nil)
+	mock.ExpectQuery(`SELECT to_regclass`).WillReturnRows(rows)
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	// Verify table doesn't exist (NULL result from to_regclass)
+	exists, err := logger.verifyTableExists()
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Expect table creation
+	mock.ExpectExec(`CREATE TABLE transactions`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// Create table
+	err = logger.createTable()
+	require.NoError(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_Run tests the Run method initialization
+func TestPostgresTransactionLogger_Run(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	if logger.events != nil {
+		t.Error("Expected events channel to be nil before Run()")
+	}
+
+	if logger.errors != nil {
+		t.Error("Expected errors channel to be nil before Run()")
+	}
+
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	if logger.events == nil {
+		t.Error("Expected events channel to be initialized after Run()")
+	}
+
+	if logger.errors == nil {
+		t.Error("Expected errors channel to be initialized after Run()")
+	}
+}
+
+// TestPostgresTransactionLogger_WritePut tests writing PUT events
+func TestPostgresTransactionLogger_WritePut(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Expect two INSERT queries
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventPut, "key1", "value1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventPut, "key2", "value2").
+		WillReturnResult(sqlmock.NewResult(2, 1))
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	logger.WritePut("key1", "value1")
+	logger.WritePut("key2", "value2")
+
+	// Give time for writes to complete
+	time.Sleep(50 * time.Millisecond)
+
+	mock.ExpectClose()
+	err = logger.Close()
+	assert.NoError(t, err)
+
+	// Give time for goroutine to process remaining events
+	time.Sleep(10 * time.Millisecond)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_WriteDelete tests writing DELETE events
+func TestPostgresTransactionLogger_WriteDelete(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Expect two INSERT queries for delete events
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventDelete, "key1", "").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventDelete, "key2", "").
+		WillReturnResult(sqlmock.NewResult(2, 1))
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	logger.WriteDelete("key1")
+	logger.WriteDelete("key2")
+
+	// Give time for writes to complete
+	time.Sleep(50 * time.Millisecond)
+
+	mock.ExpectClose()
+	err = logger.Close()
+	assert.NoError(t, err)
+
+	// Give time for goroutine to process remaining events
+	time.Sleep(10 * time.Millisecond)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_MixedOperations tests mixed PUT and DELETE operations
+func TestPostgresTransactionLogger_MixedOperations(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Expect mixed INSERT queries
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventPut, "key1", "value1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventDelete, "key2", "").
+		WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventPut, "key3", "value3").
+		WillReturnResult(sqlmock.NewResult(3, 1))
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	logger.WritePut("key1", "value1")
+	logger.WriteDelete("key2")
+	logger.WritePut("key3", "value3")
+
+	// Give time for writes to complete
+	time.Sleep(50 * time.Millisecond)
+
+	mock.ExpectClose()
+	err = logger.Close()
+	assert.NoError(t, err)
+
+	// Give time for goroutine to process remaining events
+	time.Sleep(10 * time.Millisecond)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_Err tests the Err() method
+func TestPostgresTransactionLogger_Err(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	errChan := logger.Err()
+	if errChan == nil {
+		t.Fatal("Expected non-nil error channel")
+	}
+
+	// Verify channel is initially empty
+	select {
+	case err := <-errChan:
+		t.Errorf("Expected empty error channel, got: %v", err)
+	case <-time.After(10 * time.Millisecond):
+		// Expected - no errors
+	}
+}
+
+// TestPostgresTransactionLogger_ReadEvents_EmptyTable tests reading from an empty table
+func TestPostgresTransactionLogger_ReadEvents_EmptyTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Return empty rows
+	rows := sqlmock.NewRows([]string{"sequence", "event_type", "key", "value"})
+	mock.ExpectQuery(`SELECT sequence, event_type, key, value FROM transactions`).WillReturnRows(rows)
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	eventChan, errChan := logger.ReadEvents()
+
+	// Collect all events
+	var events []Event
+	done := make(chan bool)
+
+	go func() {
+		for event := range eventChan {
+			events = append(events, event)
+		}
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timeout waiting for ReadEvents to complete")
+	}
+
+	// Check for errors
+	select {
+	case err, ok := <-errChan:
+		if ok && err != nil {
+			t.Errorf("Expected no errors, got: %v", err)
+		}
+	default:
+		// Expected - no errors
+	}
+
+	if len(events) != 0 {
+		t.Errorf("Expected 0 events from empty table, got %d", len(events))
+	}
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_ReadEvents_ValidData tests reading valid events
+func TestPostgresTransactionLogger_ReadEvents_ValidData(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Return valid rows
+	rows := sqlmock.NewRows([]string{"sequence", "event_type", "key", "value"}).
+		AddRow(1, EventPut, "key1", "value1").
+		AddRow(2, EventDelete, "key2", "").
+		AddRow(3, EventPut, "key3", "value3")
+	mock.ExpectQuery(`SELECT sequence, event_type, key, value FROM transactions`).WillReturnRows(rows)
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	eventChan, errChan := logger.ReadEvents()
+
+	// Collect all events
+	var events []Event
+	done := make(chan bool)
+
+	go func() {
+		for event := range eventChan {
+			events = append(events, event)
+		}
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timeout waiting for ReadEvents to complete")
+	}
+
+	// Check for errors
+	select {
+	case err, ok := <-errChan:
+		if ok && err != nil {
+			t.Errorf("Expected no errors, got: %v", err)
+		}
+	default:
+		// Expected - no errors
+	}
+
+	expectedEvents := []Event{
+		{Sequence: 1, Kind: EventPut, Key: "key1", Value: "value1"},
+		{Sequence: 2, Kind: EventDelete, Key: "key2", Value: ""},
+		{Sequence: 3, Kind: EventPut, Key: "key3", Value: "value3"},
+	}
+
+	if len(events) != len(expectedEvents) {
+		t.Fatalf("Expected %d events, got %d", len(expectedEvents), len(events))
+	}
+
+	for i, expected := range expectedEvents {
+		if events[i].Sequence != expected.Sequence {
+			t.Errorf("Event %d: expected sequence %d, got %d", i, expected.Sequence, events[i].Sequence)
+		}
+		if events[i].Kind != expected.Kind {
+			t.Errorf("Event %d: expected kind %d, got %d", i, expected.Kind, events[i].Kind)
+		}
+		if events[i].Key != expected.Key {
+			t.Errorf("Event %d: expected key %q, got %q", i, expected.Key, events[i].Key)
+		}
+		if events[i].Value != expected.Value {
+			t.Errorf("Event %d: expected value %q, got %q", i, expected.Value, events[i].Value)
+		}
+	}
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_ReadEvents_QueryError tests error handling when query fails
+func TestPostgresTransactionLogger_ReadEvents_QueryError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Return query error
+	mock.ExpectQuery(`SELECT sequence, event_type, key, value FROM transactions`).
+		WillReturnError(fmt.Errorf("database connection lost"))
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	eventChan, errChan := logger.ReadEvents()
+
+	// Collect all events
+	var events []Event
+	done := make(chan bool)
+
+	go func() {
+		for event := range eventChan {
+			events = append(events, event)
+		}
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timeout waiting for ReadEvents to complete")
+	}
+
+	// Check for error
+	select {
+	case err := <-errChan:
+		if err == nil {
+			t.Error("Expected error for query failure")
+		}
+		if !strings.Contains(err.Error(), "failed to read transactions") {
+			t.Errorf("Expected 'failed to read transactions' in error message, got: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected error but got none")
+	}
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_ReadEvents_ScanError tests error handling when row scan fails
+func TestPostgresTransactionLogger_ReadEvents_ScanError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Return rows with invalid data type for sequence (string instead of int)
+	rows := sqlmock.NewRows([]string{"sequence", "event_type", "key", "value"}).
+		AddRow("invalid", EventPut, "key1", "value1")
+	mock.ExpectQuery(`SELECT sequence, event_type, key, value FROM transactions`).WillReturnRows(rows)
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	eventChan, errChan := logger.ReadEvents()
+
+	// Collect all events
+	var events []Event
+	done := make(chan bool)
+
+	go func() {
+		for event := range eventChan {
+			events = append(events, event)
+		}
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		// Expected
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Timeout waiting for ReadEvents to complete")
+	}
+
+	// Check for error
+	select {
+	case err := <-errChan:
+		if err == nil {
+			t.Error("Expected error for scan failure")
+		}
+		if !strings.Contains(err.Error(), "failed to read row") {
+			t.Errorf("Expected 'failed to read row' in error message, got: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected error but got none")
+	}
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_WriteError tests error handling during writes
+func TestPostgresTransactionLogger_WriteError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Return error on INSERT
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventPut, "key1", "value1").
+		WillReturnError(fmt.Errorf("simulated write error"))
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	logger.WritePut("key1", "value1")
+
+	// Wait for error to be sent
+	select {
+	case err := <-logger.Err():
+		if err == nil {
+			t.Error("Expected error from failing write")
+		}
+		if !strings.Contains(err.Error(), "simulated write error") {
+			t.Errorf("Expected 'simulated write error' in error message, got: %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected error but got none")
+	}
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_SequenceIncrement tests that multiple writes work correctly
+func TestPostgresTransactionLogger_SequenceIncrement(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Expect 10 INSERT queries
+	for i := 1; i <= 10; i++ {
+		mock.ExpectExec(`INSERT INTO transactions`).
+			WithArgs(EventPut, fmt.Sprintf("key%d", i), fmt.Sprintf("value%d", i)).
+			WillReturnResult(sqlmock.NewResult(int64(i), 1))
+	}
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Write multiple events
+	for i := 1; i <= 10; i++ {
+		logger.WritePut(fmt.Sprintf("key%d", i), fmt.Sprintf("value%d", i))
+	}
+
+	// Give time for writes to complete
+	time.Sleep(100 * time.Millisecond)
+
+	mock.ExpectClose()
+	err = logger.Close()
+	assert.NoError(t, err)
+
+	// Give time for goroutine to process remaining events
+	time.Sleep(10 * time.Millisecond)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_verifyTableExists tests table existence check
+func TestPostgresTransactionLogger_verifyTableExists(t *testing.T) {
+	t.Run("table exists", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer dbCleanup(t, db, mock)
+
+		rows := sqlmock.NewRows([]string{"to_regclass"}).AddRow("transactions")
+		mock.ExpectQuery(`SELECT to_regclass`).WillReturnRows(rows)
+
+		logger := &PostgresTransactionLogger{db: db}
+
+		exists, err := logger.verifyTableExists()
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		err = mock.ExpectationsWereMet()
+		assert.NoError(t, err)
+	})
+
+	t.Run("table does not exist - empty result", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer dbCleanup(t, db, mock)
+
+		// Return no rows - simulates case where table doesn't exist
+		rows := sqlmock.NewRows([]string{"to_regclass"})
+		mock.ExpectQuery(`SELECT to_regclass`).WillReturnRows(rows)
+
+		logger := &PostgresTransactionLogger{db: db}
+
+		exists, err := logger.verifyTableExists()
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		err = mock.ExpectationsWereMet()
+		assert.NoError(t, err)
+	})
+
+	t.Run("table does not exist - NULL result", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer dbCleanup(t, db, mock)
+
+		// Return NULL - this is what PostgreSQL's to_regclass returns when table doesn't exist
+		rows := sqlmock.NewRows([]string{"to_regclass"}).AddRow(nil)
+		mock.ExpectQuery(`SELECT to_regclass`).WillReturnRows(rows)
+
+		logger := &PostgresTransactionLogger{db: db}
+
+		exists, err := logger.verifyTableExists()
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		err = mock.ExpectationsWereMet()
+		assert.NoError(t, err)
+	})
+}
+
+// TestPostgresTransactionLogger_verifyTableExists_Error tests error handling in table check
+func TestPostgresTransactionLogger_verifyTableExists_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	mock.ExpectQuery(`SELECT to_regclass`).WillReturnError(fmt.Errorf("database error"))
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	_, err = logger.verifyTableExists()
+	assert.Error(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_createTable tests table creation
+func TestPostgresTransactionLogger_createTable(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	mock.ExpectExec(`CREATE TABLE transactions`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	err = logger.createTable()
+	require.NoError(t, err)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_createTable_Error tests error handling in table creation
+func TestPostgresTransactionLogger_createTable_Error(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	mock.ExpectExec(`CREATE TABLE transactions`).WillReturnError(fmt.Errorf("table already exists"))
+
+	logger := &PostgresTransactionLogger{db: db}
+
+	err = logger.createTable()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to create table")
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+// TestPostgresTransactionLogger_Close tests the Close method
+func TestPostgresTransactionLogger_Close(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer dbCleanup(t, db, mock)
+
+	// Set up expectations for write
+	mock.ExpectExec(`INSERT INTO transactions`).
+		WithArgs(EventPut, "key1", "value1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	logger := &PostgresTransactionLogger{db: db}
+	logger.Run()
+
+	// Give goroutine time to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Write an event
+	logger.WritePut("key1", "value1")
+
+	// Give time for write to complete
+	time.Sleep(50 * time.Millisecond)
+
+	// Close should not return an error
+	mock.ExpectClose()
+	err = logger.Close()
+	assert.NoError(t, err)
+
+	// Give time for goroutine to finish
+	time.Sleep(10 * time.Millisecond)
+
+	err = mock.ExpectationsWereMet()
+	assert.NoError(t, err)
+}
+
+func dbCleanup(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) {
+	mock.ExpectClose()
+	err := db.Close()
+	assert.NoError(t, err)
+}

--- a/internal/pkg/logger/postgres_test.go
+++ b/internal/pkg/logger/postgres_test.go
@@ -107,6 +107,7 @@ func TestPostgresTransactionLogger_WritePut(t *testing.T) {
 	mock.ExpectExec(`INSERT INTO transactions`).
 		WithArgs(EventPut, "key2", "value2").
 		WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectClose()
 
 	logger := &PostgresTransactionLogger{db: db}
 	logger.Run()
@@ -120,7 +121,6 @@ func TestPostgresTransactionLogger_WritePut(t *testing.T) {
 	// Give time for writes to complete
 	time.Sleep(50 * time.Millisecond)
 
-	mock.ExpectClose()
 	err = logger.Close()
 	assert.NoError(t, err)
 
@@ -144,6 +144,7 @@ func TestPostgresTransactionLogger_WriteDelete(t *testing.T) {
 	mock.ExpectExec(`INSERT INTO transactions`).
 		WithArgs(EventDelete, "key2", "").
 		WillReturnResult(sqlmock.NewResult(2, 1))
+	mock.ExpectClose()
 
 	logger := &PostgresTransactionLogger{db: db}
 	logger.Run()
@@ -157,7 +158,6 @@ func TestPostgresTransactionLogger_WriteDelete(t *testing.T) {
 	// Give time for writes to complete
 	time.Sleep(50 * time.Millisecond)
 
-	mock.ExpectClose()
 	err = logger.Close()
 	assert.NoError(t, err)
 
@@ -184,6 +184,7 @@ func TestPostgresTransactionLogger_MixedOperations(t *testing.T) {
 	mock.ExpectExec(`INSERT INTO transactions`).
 		WithArgs(EventPut, "key3", "value3").
 		WillReturnResult(sqlmock.NewResult(3, 1))
+	mock.ExpectClose()
 
 	logger := &PostgresTransactionLogger{db: db}
 	logger.Run()
@@ -198,7 +199,6 @@ func TestPostgresTransactionLogger_MixedOperations(t *testing.T) {
 	// Give time for writes to complete
 	time.Sleep(50 * time.Millisecond)
 
-	mock.ExpectClose()
 	err = logger.Close()
 	assert.NoError(t, err)
 
@@ -503,6 +503,7 @@ func TestPostgresTransactionLogger_SequenceIncrement(t *testing.T) {
 			WithArgs(EventPut, fmt.Sprintf("key%d", i), fmt.Sprintf("value%d", i)).
 			WillReturnResult(sqlmock.NewResult(int64(i), 1))
 	}
+	mock.ExpectClose()
 
 	logger := &PostgresTransactionLogger{db: db}
 	logger.Run()
@@ -518,7 +519,6 @@ func TestPostgresTransactionLogger_SequenceIncrement(t *testing.T) {
 	// Give time for writes to complete
 	time.Sleep(100 * time.Millisecond)
 
-	mock.ExpectClose()
 	err = logger.Close()
 	assert.NoError(t, err)
 
@@ -650,6 +650,7 @@ func TestPostgresTransactionLogger_Close(t *testing.T) {
 	mock.ExpectExec(`INSERT INTO transactions`).
 		WithArgs(EventPut, "key1", "value1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectClose()
 
 	logger := &PostgresTransactionLogger{db: db}
 	logger.Run()
@@ -664,7 +665,6 @@ func TestPostgresTransactionLogger_Close(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	// Close should not return an error
-	mock.ExpectClose()
 	err = logger.Close()
 	assert.NoError(t, err)
 

--- a/internal/pkg/logger/postgres_test.go
+++ b/internal/pkg/logger/postgres_test.go
@@ -16,7 +16,7 @@ import (
 func TestNewPostgresTransactionLogger(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	defer db.Close()
+	defer dbCleanup(t, db, mock)
 
 	// Expect ping
 	mock.ExpectPing()


### PR DESCRIPTION
- Brought in https://github.com/DATA-DOG/go-sqlmock for unit testing the postgres logger
- Found a couple minor bugs in `verifyTableExists()`
    - NULL result handling
    - defered rows.Close() on a nil row
- Realized the Close() method didn't close the db connection. Fixed that as well.