### PR TITLE
Add postgres to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Various items for cleanup.
 - [ ] Add healthz endpoints for service health checking
 
 ### Deployment
-- [ ] Add postgres to docker compose setup for local dev
+- [x] Add postgres to docker compose setup for local dev
 - [ ] Generate a valid cert via LetsEncrypt
 - [ ] Utilize mtls termination between traefik and api services
 - [ ] Enable SSL with Postgres

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Various items for cleanup.
   - [ ] Provide useful code snippets for cli execution
   - [ ] Document the API(s)
   - [x] Document prerequisites and general dev setup
-- [X] Set up CI
-  - [X] Linting w/ golangci-lint
+- [x] Set up CI
+  - [x] Linting w/ golangci-lint
   - [x] Testing
-  - [X] Report test coverage in PR and on project README
+  - [x] Report test coverage in PR and on project README
   - [x] Build docker container
-- [ ] Bring in Just for encapsulating typical project commands
+- [x] Bring in Just for encapsulating typical project commands
 
 ### Service
 - [x] Update Go + Deps
@@ -97,7 +97,17 @@ Various items for cleanup.
 - [ ] Restructure main for better configurability
   - [ ] Add in env var/cli configuration setting
   - [ ] Reconsider defaults
-- [ ] Improve unit and integration testing
+- [ ] Improve Tests
+  - [ ] Improve unit tests
+    - [x] Better coverage for file logger 
+    - [x] Better coverage for PG logger
+    - [ ] Better coverage for service layer
+  - [ ] Add integration testing
+    - [ ] File logger
+    - [ ] Postgres logger
+  - [ ] Add end-to-end testing (hitting http endpoints from outside the service)
+  - [ ] Smoke test main (using github.com/rogpeppe/go-internal/testscript)
+  - [ ] Handling combining test coverage in CI (unit + integration + smoke)
 - [X] Refactor to use standard Go project layouts
 - [ ] Drop gorilla/mux for chi (https://github.com/go-chi/chi)
 - [ ] Drop lib/pq for pgx (https://github.com/jackc/pgx)
@@ -112,6 +122,7 @@ Various items for cleanup.
 - [ ] Add healthz endpoints for service health checking
 
 ### Deployment
+- [ ] Add postgres to docker compose setup for local dev
 - [ ] Generate a valid cert via LetsEncrypt
 - [ ] Utilize mtls termination between traefik and api services
 - [ ] Enable SSL with Postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
         condition: service_healthy
       create-log:
         condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=Host(`localhost`)"
@@ -72,6 +74,23 @@ services:
           echo "transaction log already exists"
         fi
       '
+
+  # postgres database for transaction logging
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: lockbox
+      POSTGRES_PASSWORD: lockbox
+      POSTGRES_DB: lockbox
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U lockbox -d lockbox"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
 
   # load balancing and TLS termination
   traefik:
@@ -142,3 +161,4 @@ volumes:
   go-build-cache:
   certs:  # shared volume for certificates
   sync: # shared volume for transaction logger file
+  postgres-data: # persistent volume for postgres data


### PR DESCRIPTION
Added postgres to our docker compose setup so that we can use the PGLogger more conveniently and add integration testing.